### PR TITLE
Improve Dante whitelist script configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# fancy
+# Dante Setup Script
+
+This repository contains a helper script for installing and configuring a Dante SOCKS server on Debian/Ubuntu systems with an IP allow-list.
+
+## Prerequisites
+
+- A Debian or Ubuntu host with `apt` package management.
+- Root privileges to install packages and modify `/etc/danted.conf`.
+
+## Usage
+
+To download the script straight from GitHub and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/d3vw/fancy/main/setup_dante.sh -o setup_dante.sh
+chmod +x setup_dante.sh
+sudo ./setup_dante.sh -a 203.0.113.5 -a 198.51.100.0/24 -p 1090
+```
+
+### Options
+
+- `-a <ip_or_cidr>` – Add one or more IP addresses or CIDR ranges (comma-separated) that are allowed to use the proxy. You can repeat the option.
+- `-p <port>` – Port that the Dante server should listen on. Defaults to `1080`.
+- `-h` – Show the built-in help text.
+
+The script will:
+
+1. Install the `dante-server` package via `apt` if it is not already installed.
+2. Detect the default network interface used for outbound traffic.
+3. Back up any existing `/etc/danted.conf` file with a timestamp suffix.
+4. Write a new configuration that only allows the specified client networks and uses a passwordless SOCKS policy for those
+   clients.
+5. Enable and restart the `danted` systemd service.
+
+After the script completes successfully, the Dante server will be listening on the requested port and only the IPs/CIDR blocks supplied through the `-a` option will be permitted.

--- a/setup_dante.sh
+++ b/setup_dante.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<USAGE
+Usage: $0 -a <ip_or_cidr>[,<ip_or_cidr>...] [-a <ip_or_cidr>[,<ip_or_cidr>...]] ... [-p <port>]
+
+Options:
+  -a    Comma-separated list of client IP addresses or networks (CIDR) allowed to use the proxy.
+        Repeat the option to add more entries. At least one allow-list entry is required.
+  -p    Port that Dante should listen on (default: 1080).
+  -h    Display this help message.
+USAGE
+}
+
+require_root() {
+    if [[ $(id -u) -ne 0 ]]; then
+        echo "[ERROR] This script must be run as root." >&2
+        exit 1
+    fi
+}
+
+validate_port() {
+    local port=$1
+    if ! [[ $port =~ ^[0-9]+$ ]] || ((port < 1 || port > 65535)); then
+        echo "[ERROR] Invalid port: $port. Must be an integer between 1 and 65535." >&2
+        exit 1
+    fi
+}
+
+split_and_append_ips() {
+    local input=$1
+    local entry ip octet
+    local -a entries octets
+    local old_ifs=$IFS
+
+    IFS=',' read -ra entries <<< "$input"
+    IFS=$old_ifs
+
+    for entry in "${entries[@]}"; do
+        entry=$(echo "$entry" | xargs)
+        if [[ -z $entry ]]; then
+            continue
+        fi
+        if ! [[ $entry =~ ^([0-9]{1,3}(\.[0-9]{1,3}){3})(/(3[0-2]|[12]?[0-9]))?$ ]]; then
+            echo "[ERROR] Invalid IPv4 or CIDR block: $entry" >&2
+            exit 1
+        fi
+        # basic octet check
+        ip=${entry%%/*}
+
+        old_ifs=$IFS
+        IFS='.' read -r -a octets <<< "$ip"
+        IFS=$old_ifs
+
+        for octet in "${octets[@]}"; do
+            if ((octet < 0 || octet > 255)); then
+                echo "[ERROR] Invalid IPv4 address octet in: $entry" >&2
+                exit 1
+            fi
+        done
+        ALLOW_LIST+=("$entry")
+    done
+}
+
+get_default_interface() {
+    local iface
+    iface=$(ip route show default 2>/dev/null | awk '/default/ {print $5; exit}')
+    if [[ -z $iface ]]; then
+        echo "[ERROR] Could not determine the default network interface." >&2
+        exit 1
+    fi
+    echo "$iface"
+}
+
+backup_config() {
+    local config_path=$1
+    if [[ -f $config_path ]]; then
+        local timestamp
+        timestamp=$(date +%Y%m%d%H%M%S)
+        cp "$config_path" "${config_path}.bak-${timestamp}"
+    fi
+}
+
+write_config() {
+    local config_path=$1
+    local port=$2
+    local iface=$3
+    shift 3
+    local allow_list=("$@")
+
+    {
+        echo "logoutput: syslog"
+        echo "internal: 0.0.0.0 port = $port"
+        echo "external: $iface"
+        echo "clientmethod: none"
+        echo "socksmethod: none"
+        echo "user.privileged: root"
+        echo "user.notprivileged: nobody"
+        echo "user.libwrap: nobody"
+        echo "client pass {"
+        for cidr in "${allow_list[@]}"; do
+            echo "    from: $cidr"
+        done
+        echo "    to: 0.0.0.0/0"
+        echo "    log: connect disconnect error"
+        echo "}"
+        echo "client block {"
+        echo "    from: 0.0.0.0/0"
+        echo "    to: 0.0.0.0/0"
+        echo "    log: connect error"
+        echo "}"
+        for cidr in "${allow_list[@]}"; do
+            echo "pass {"
+            echo "    from: $cidr"
+            echo "    to: 0.0.0.0/0"
+            echo "    protocol: tcp udp"
+            echo "    log: connect disconnect error"
+            echo "}"
+        done
+        echo "block {"
+        echo "    from: 0.0.0.0/0"
+        echo "    to: 0.0.0.0/0"
+        echo "    log: connect error"
+        echo "}"
+    } > "$config_path"
+}
+
+restart_service() {
+    systemctl daemon-reload
+    systemctl enable danted
+    systemctl restart danted
+}
+
+main() {
+    require_root
+
+    local port=1080
+    ALLOW_LIST=()
+
+    while getopts ":a:p:h" opt; do
+        case $opt in
+            a)
+                split_and_append_ips "$OPTARG"
+                ;;
+            p)
+                validate_port "$OPTARG"
+                port=$OPTARG
+                ;;
+            h)
+                usage
+                exit 0
+                ;;
+            :)
+                echo "[ERROR] Option -$OPTARG requires an argument." >&2
+                usage
+                exit 1
+                ;;
+            \?)
+                echo "[ERROR] Invalid option: -$OPTARG" >&2
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    shift $((OPTIND - 1))
+
+    if [[ ${#ALLOW_LIST[@]} -eq 0 ]]; then
+        echo "[ERROR] At least one -a option specifying allowed IP/CIDR is required." >&2
+        usage
+        exit 1
+    fi
+
+    echo "[INFO] Installing Dante server package..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y dante-server
+
+    local config_path="/etc/danted.conf"
+    local iface
+    iface=$(get_default_interface)
+
+    echo "[INFO] Backing up existing configuration (if any)..."
+    backup_config "$config_path"
+
+    echo "[INFO] Writing new configuration..."
+    write_config "$config_path" "$port" "$iface" "${ALLOW_LIST[@]}"
+
+    echo "[INFO] Restarting Dante service..."
+    restart_service
+
+    echo "[SUCCESS] Dante server is configured to listen on port $port"
+    echo "          Allowed clients: ${ALLOW_LIST[*]}"
+    echo "          Default interface: $iface"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- document how to download the setup script from GitHub Raw with the repository path pre-filled
- harden allow-list parsing and emit a whitelist-friendly Dante configuration that sets client and SOCKS methods explicitly

## Testing
- bash -n setup_dante.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce4104401c8330841a93d0d6664d9f