### PR TITLE
Allow multiple allow-list arguments for the Dante setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# fancy
+# Dante Setup Script
+
+This repository contains a helper script for installing and configuring a Dante SOCKS server on Debian/Ubuntu systems with an IP allow-list.
+
+## Prerequisites
+
+- A Debian or Ubuntu host with `apt` package management.
+- Root privileges to install packages and modify `/etc/danted.conf`.
+
+## Usage
+
+To download the script straight from GitHub and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/d3vw/fancy/main/setup_dante.sh -o setup_dante.sh
+chmod +x setup_dante.sh
+sudo ./setup_dante.sh -a 203.0.113.5 -a 198.51.100.0/24 -p 1090
+```
+
+### Options
+
+- `-a <ip_or_cidr>` – Add one or more IP addresses or CIDR ranges that are allowed to use the proxy. Provide additional addresses after the same `-a` separated by spaces or commas, or repeat the option multiple times.
+- `-p <port>` – Port that the Dante server should listen on. Defaults to `1080`.
+- `-h` – Show the built-in help text.
+
+The script will:
+
+1. Install the `dante-server` package via `apt` if it is not already installed.
+2. Detect the default network interface used for outbound traffic.
+3. Back up any existing `/etc/danted.conf` file with a timestamp suffix.
+4. Write a new configuration that only allows the specified client networks and uses a passwordless SOCKS policy for those
+   clients.
+5. Enable and restart the `danted` systemd service.
+
+After the script completes successfully, the Dante server will be listening on the requested port and only the IPs/CIDR blocks supplied through the `-a` option will be permitted.


### PR DESCRIPTION
## Summary
- document how to download the setup script from GitHub Raw with the repository path pre-filled
- harden allow-list parsing and emit a whitelist-friendly Dante configuration that sets client and SOCKS methods explicitly
- accept multiple `-a` arguments and space- or comma-separated allow-list values when configuring Dante

## Testing
- bash -n setup_dante.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce4104401c8330841a93d0d6664d9f