### PR TITLE
Normalize single IP addresses in Dante setup

### DIFF
--- a/setup_dante.sh
+++ b/setup_dante.sh
@@ -60,6 +60,9 @@ split_and_append_ips() {
                 exit 1
             fi
         done
+        if [[ $entry != */* ]]; then
+            entry+="/32"
+        fi
         ALLOW_LIST+=("$entry")
     done
 }


### PR DESCRIPTION
## Summary
- ensure standalone IPv4 addresses supplied via `-a` are stored as `/32` CIDR blocks
- prevent Dante configuration errors by always emitting explicit netmasks for allow-list entries

## Testing
- bash -n setup_dante.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce4cf8ecdc8330b1b6419257a2085e