### PR TITLE
Fix Dante config generation for multiple client entries

### DIFF
--- a/setup_dante.sh
+++ b/setup_dante.sh
@@ -102,13 +102,13 @@ write_config() {
         echo "user.privileged: root"
         echo "user.notprivileged: nobody"
         echo "user.libwrap: nobody"
-        echo "client pass {"
         for cidr in "${allow_list[@]}"; do
+            echo "client pass {"
             echo "    from: $cidr"
+            echo "    to: 0.0.0.0/0"
+            echo "    log: connect disconnect error"
+            echo "}"
         done
-        echo "    to: 0.0.0.0/0"
-        echo "    log: connect disconnect error"
-        echo "}"
         echo "client block {"
         echo "    from: 0.0.0.0/0"
         echo "    to: 0.0.0.0/0"


### PR DESCRIPTION
## Summary
- generate one client pass block per allowed CIDR instead of combining the entries in a single block
- prevents danted from failing to start when multiple client networks are supplied

## Testing
- shellcheck setup_dante.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce60c0eee8833084137d81a8038dca