### PR TITLE
Add support for managing Dante client allow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ sudo ./setup_dante.sh -a 203.0.113.5 -a 198.51.100.0/24 -p 1090
 
 
 - `-a <ip_or_cidr>` – Add one or more IP addresses or CIDR ranges (comma-separated) that are allowed to use the proxy. You can repeat the option.
+- `-r <ip_or_cidr>` – Remove one or more IP addresses or CIDR ranges (comma-separated) from the allow-list. You can repeat the option.
 - `-p <port>` – Port that the Dante server should listen on. Defaults to `1080`.
 - `-h` – Show the built-in help text.
 
@@ -33,4 +34,4 @@ The script will:
    clients.
 5. Enable and restart the `danted` systemd service.
 
-After the script completes successfully, the Dante server will be listening on the requested port and only the IPs/CIDR blocks supplied through the `-a` option will be permitted.
+After the script completes successfully, the Dante server will be listening on the requested port and only the IPs/CIDR blocks that remain after applying any `-a` and `-r` options will be permitted.

--- a/setup_dante.sh
+++ b/setup_dante.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+declare -a ALLOW_LIST=()
+declare -a ADD_LIST=()
+declare -a REMOVE_LIST=()
+
 usage() {
     cat <<USAGE
 
-Usage: $0 -a <ip_or_cidr>[,<ip_or_cidr>...] [-a <ip_or_cidr>[,<ip_or_cidr>...]] ... [-p <port>]
+Usage: $0 [-a <ip_or_cidr>[,<ip_or_cidr>...]]... [-r <ip_or_cidr>[,<ip_or_cidr>...]]... [-p <port>]
 
 Options:
-  -a    Comma-separated list of client IP addresses or networks (CIDR) allowed to use the proxy.
-        Repeat the option to add more entries. At least one allow-list entry is required.
+  -a    Comma-separated list of client IP addresses or networks (CIDR) to add to the allow-list.
+        Repeat the option to add more entries. At least one allow-list entry must remain.
+  -r    Comma-separated list of client IP addresses or networks (CIDR) to remove from the allow-list.
+        Repeat the option to remove more entries.
   -p    Port that Dante should listen on (default: 1080).
   -h    Display this help message.
 USAGE
@@ -31,9 +37,11 @@ validate_port() {
 
 split_and_append_ips() {
     local input=$1
+    local array_name=$2
     local entry ip octet
     local -a entries octets
     local old_ifs=$IFS
+    local -n target=$array_name
 
     IFS=',' read -ra entries <<< "$input"
     IFS=$old_ifs
@@ -63,8 +71,53 @@ split_and_append_ips() {
         if [[ $entry != */* ]]; then
             entry+="/32"
         fi
-        ALLOW_LIST+=("$entry")
+        target+=("$entry")
     done
+}
+
+array_contains() {
+    local array_name=$1
+    local needle=$2
+    local value
+    local -n haystack=$array_name
+
+    for value in "${haystack[@]}"; do
+        if [[ $value == "$needle" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+remove_from_array() {
+    local array_name=$1
+    local needle=$2
+    local value
+    local -a result=()
+    local -n haystack=$array_name
+
+    for value in "${haystack[@]}"; do
+        if [[ $value != "$needle" ]]; then
+            result+=("$value")
+        fi
+    done
+
+    haystack=("${result[@]}")
+}
+
+read_existing_allow_list() {
+    local config_path=$1
+    ALLOW_LIST=()
+
+    if [[ ! -f $config_path ]]; then
+        return
+    fi
+
+    while IFS= read -r line; do
+        if [[ $line =~ ^[[:space:]]*from:[[:space:]]*([^[:space:]]+) ]]; then
+            ALLOW_LIST+=("${BASH_REMATCH[1]}")
+        fi
+    done < <(awk '/client pass {/,/}/' "$config_path")
 }
 
 get_default_interface() {
@@ -141,11 +194,16 @@ main() {
 
     local port=1080
     ALLOW_LIST=()
+    ADD_LIST=()
+    REMOVE_LIST=()
 
-    while getopts ":a:p:h" opt; do
+    while getopts ":a:r:p:h" opt; do
         case $opt in
             a)
-                split_and_append_ips "$OPTARG"
+                split_and_append_ips "$OPTARG" ADD_LIST
+                ;;
+            r)
+                split_and_append_ips "$OPTARG" REMOVE_LIST
                 ;;
             p)
                 validate_port "$OPTARG"
@@ -171,9 +229,34 @@ main() {
 
     shift $((OPTIND - 1))
 
-    if [[ ${#ALLOW_LIST[@]} -eq 0 ]]; then
-        echo "[ERROR] At least one -a option specifying allowed IP/CIDR is required." >&2
+    local config_path="/etc/danted.conf"
+
+    read_existing_allow_list "$config_path"
+
+    if [[ ${#ALLOW_LIST[@]} -eq 0 && ${#ADD_LIST[@]} -eq 0 ]]; then
+        echo "[ERROR] No existing allow-list entries found. Use -a to specify at least one client IP/CIDR." >&2
         usage
+        exit 1
+    fi
+
+    local entry
+
+    for entry in "${ADD_LIST[@]}"; do
+        if ! array_contains ALLOW_LIST "$entry"; then
+            ALLOW_LIST+=("$entry")
+        fi
+    done
+
+    for entry in "${REMOVE_LIST[@]}"; do
+        if array_contains ALLOW_LIST "$entry"; then
+            remove_from_array ALLOW_LIST "$entry"
+        else
+            echo "[WARN] Client $entry not present in allow-list; skipping removal." >&2
+        fi
+    done
+
+    if [[ ${#ALLOW_LIST[@]} -eq 0 ]]; then
+        echo "[ERROR] At least one allowed client IP/CIDR must remain after applying changes." >&2
         exit 1
     fi
 
@@ -182,7 +265,6 @@ main() {
     apt-get update
     apt-get install -y dante-server
 
-    local config_path="/etc/danted.conf"
     local iface
     iface=$(get_default_interface)
 
@@ -196,6 +278,12 @@ main() {
     restart_service
 
     echo "[SUCCESS] Dante server is configured to listen on port $port"
+    if [[ ${#ADD_LIST[@]} -gt 0 ]]; then
+        echo "          Added clients: ${ADD_LIST[*]}"
+    fi
+    if [[ ${#REMOVE_LIST[@]} -gt 0 ]]; then
+        echo "          Removed clients: ${REMOVE_LIST[*]}"
+    fi
     echo "          Allowed clients: ${ALLOW_LIST[*]}"
     echo "          Default interface: $iface"
 }


### PR DESCRIPTION
## Summary
- allow the setup script to read the existing Dante configuration and retain the current allow-list
- add support for `-a` additions and new `-r` removals so administrators can manage client IPs incrementally
- update the README to document the new options and clarified behavior

## Testing
- bash -n setup_dante.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce7a36ba4c8330a71c8d1c052bb28a